### PR TITLE
:sparkles: 元のテキストがそのまま帰ってきたときは、元ページに手を加えない

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -105,6 +105,7 @@ export const newPage = async (init?: NewPageInit) => {
 
     // 書き込みに成功したらもとのテキストを消す
     const text = result.text;
+    if (selectedText === text) return;
     await patch(scrapbox.Project.name, scrapbox.Page.title, (lines) => {
       const lines_ = lines.map((line) => line.text);
       return [


### PR DESCRIPTION
close [⬜️custom-new-pageに選択範囲を残すoptionを入れる@2023-02-04](https://scrapbox.io/takker/⬜️custom-new-pageに選択範囲を残すoptionを入れる@2023-02-04)