### PR TITLE
:boom::zap: Use internal lines instead of `scrapbox.Page.lines`

### DIFF
--- a/deps/scrapbox.ts
+++ b/deps/scrapbox.ts
@@ -1,5 +1,5 @@
 export type {
-  Line,
+  BaseLine,
   Scrapbox,
 } from "https://raw.githubusercontent.com/scrapbox-jp/types/0.4.2/userscript.ts";
 export {
@@ -11,6 +11,7 @@ export {
   makeSocket,
   openInTheSameTab,
   patch,
+  takeInternalLines,
   useStatusBar,
 } from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.23.1/mod.ts";
 export type {

--- a/hook.ts
+++ b/hook.ts
@@ -1,5 +1,5 @@
 // ported from https://scrapbox.io/takker/custom-new-page-3
-import type { Line, patch } from "./deps/scrapbox.ts";
+import type { BaseLine, patch } from "./deps/scrapbox.ts";
 import { getIndentCount } from "./deps/scrapbox.ts";
 
 export type Updater = Parameters<typeof patch>[2];
@@ -65,7 +65,7 @@ export interface NewPageHookOptions {
   projectTo: string;
 
   /** 切り出し範囲を含む行 */
-  lines: Line[];
+  lines: BaseLine[];
 
   /** 切り出したページを開く方法 */
   mode: OpenMode;

--- a/mod.ts
+++ b/mod.ts
@@ -8,6 +8,7 @@ import {
   Scrapbox,
   sleep,
   Socket,
+  takeInternalLines,
   useStatusBar,
 } from "./deps/scrapbox.ts";
 import { getSelection } from "./selection.ts";
@@ -71,7 +72,7 @@ export const makeNewPage = (
         title: scrapbox.Page.title,
         projectFrom: scrapbox.Project.name,
         projectTo: project,
-        lines: scrapbox.Page.lines.slice(start.line, end.line + 1),
+        lines: takeInternalLines().slice(start.line, end.line + 1),
         mode,
       });
       if (result) return [hook.hookName, result] as const;


### PR DESCRIPTION
close [✅選択範囲を変えるたびにscrapbox.Page.linesをdeep copyするのをやめる](https://scrapbox.io/takker/✅選択範囲を変えるたびにscrapbox.Page.linesをdeep_copyするのをやめる)